### PR TITLE
Fix github action branch specifications.

### DIFF
--- a/.github/workflows/build-chimbuko-spack-dev-ddb.yml
+++ b/.github/workflows/build-chimbuko-spack-dev-ddb.yml
@@ -43,9 +43,12 @@ jobs:
     - name: Pull chimbuko/chimbuko-spack-env docker image
       shell: bash
       run: |
-        docker pull ghcr.io/${{ github.repository_owner }}/chimbuko/chimbuko-spack-env:ubuntu18.04
+        export OWNER_LOWER="$(\
+            echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]'\
+        )"
+        docker pull ghcr.io/$OWNER_LOWER/chimbuko/chimbuko-spack-env:ubuntu18.04
         docker image tag \
-          ghcr.io/${{ github.repository_owner }}/chimbuko/chimbuko-spack-env:ubuntu18.04 \
+          ghcr.io/$OWNER_LOWER/chimbuko/chimbuko-spack-env:ubuntu18.04 \
           chimbuko/chimbuko-spack-env:ubuntu18.04
 
     - name: Build test environment image
@@ -60,6 +63,9 @@ jobs:
     - name: Push chimbuko-spack-dev-ddb image
       shell: bash
       run: |
+        export OWNER_LOWER="$(\
+            echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]'\
+        )"
         docker image tag chimbuko/chimbuko-spack-dev-ddb:ubuntu18.04 \
-          ghcr.io/${{ github.repository_owner }}/chimbuko/chimbuko-spack-dev-ddb:ubuntu18.04
-        docker image push ghcr.io/${{ github.repository_owner }}/chimbuko/chimbuko-spack-dev-ddb:ubuntu18.04
+          ghcr.io/$OWNER_LOWER/chimbuko/chimbuko-spack-dev-ddb:ubuntu18.04
+        docker image push ghcr.io/$OWNER_LOWER/chimbuko/chimbuko-spack-dev-ddb:ubuntu18.04

--- a/.github/workflows/build-chimbuko-spack-dev-ddb.yml
+++ b/.github/workflows/build-chimbuko-spack-dev-ddb.yml
@@ -18,7 +18,6 @@ jobs:
       uses: actions/checkout@v5
       with:
         path: 'ChimbukoVisualizationII'
-        ref: 'actions_unstable'
 
     - name: Check out the PerformanceAnalysis repo
       uses: actions/checkout@v5

--- a/.github/workflows/build-chimbuko-spack-env.yml
+++ b/.github/workflows/build-chimbuko-spack-env.yml
@@ -52,6 +52,9 @@ jobs:
     - name: Push PerformanceAnalysis image
       shell: bash
       run: |
+        export OWNER_LOWER="$(\
+            echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]'\
+        )"
         docker image tag chimbuko/chimbuko-spack-env:ubuntu18.04 \
-          ghcr.io/${{ github.repository_owner }}/chimbuko/chimbuko-spack-env:ubuntu18.04
-        docker image push ghcr.io/${{ github.repository_owner }}/chimbuko/chimbuko-spack-env:ubuntu18.04
+          ghcr.io/$OWNER_LOWER/chimbuko/chimbuko-spack-env:ubuntu18.04
+        docker image push ghcr.io/$OWNER_LOWER/chimbuko/chimbuko-spack-env:ubuntu18.04

--- a/.github/workflows/build-chimbuko-spack-env.yml
+++ b/.github/workflows/build-chimbuko-spack-env.yml
@@ -18,7 +18,6 @@ jobs:
       uses: actions/checkout@v5
       with:
         path: 'ChimbukoVisualizationII'
-        ref: 'actions'
 
     - name: Check out the PerformanceAnalysis repo
       uses: actions/checkout@v5

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -28,9 +28,12 @@ jobs:
     - name: Pull chimbuko/chimbuko-spack-dev-ddb docker image
       shell: bash
       run: |
-        docker pull ghcr.io/${{ github.repository_owner }}/chimbuko/chimbuko-spack-dev-ddb:ubuntu18.04
+        export OWNER_LOWER="$(\
+            echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]'\
+        )"
+        docker pull ghcr.io/$OWNER_LOWER/chimbuko/chimbuko-spack-dev-ddb:ubuntu18.04
         docker image tag \
-          ghcr.io/${{ github.repository_owner }}/chimbuko/chimbuko-spack-dev-ddb:ubuntu18.04 \
+          ghcr.io/$OWNER_LOWER/chimbuko/chimbuko-spack-dev-ddb:ubuntu18.04 \
           chimbuko/chimbuko-spack-dev-ddb:ubuntu18.04
 
     - name: Run tests in container

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -17,8 +17,6 @@ jobs:
     # Check out ChimubkoVisualizationII (CV2) repo.
     - name: Check out the CV2 repo
       uses: actions/checkout@v4
-      with:
-        ref: 'actions_unstable'
 
     - name: Check out the PerformanceAnalysis repo
       uses: actions/checkout@v4
@@ -47,5 +45,3 @@ jobs:
               --volume $(pwd):$(pwd) \
               chimbuko/chimbuko-spack-dev-ddb:ubuntu18.04 \
               -c "$(pwd)/docker/e2e-test.sh"
-
-

--- a/docker/e2e-test.sh
+++ b/docker/e2e-test.sh
@@ -4,11 +4,8 @@ set -eux pipefail
 
 env
 
-ls -halF $RUN_DIR
-
 pushd $RUN_DIR
 git config --global --add safe.directory $RUN_DIR
-git checkout actions_unstable
 
 mkdir -p data/grid
 ln -s /Downloads/repeat_1rank data/grid/


### PR DESCRIPTION
The previous actions had leftover branch information which is not necessary once merged to the default branch.